### PR TITLE
Scale Tetris interface to fit viewport

### DIFF
--- a/tetris/css/styles.css
+++ b/tetris/css/styles.css
@@ -24,6 +24,7 @@ body{
   margin:0; background:var(--bg); color:var(--text);
   font:500 16px/1.4 system-ui,Segoe UI,Roboto,Arial,sans-serif;
   -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  overflow:hidden;
 }
 
 #app{

--- a/tetris/js/main.js
+++ b/tetris/js/main.js
@@ -142,6 +142,30 @@ setupTouch();
 // Focus inicial en el canvas para teclado
 canvas.addEventListener('pointerdown', ()=> canvas.focus(), {passive:true});
 canvas.tabIndex = 0;
+// Escalar la interfaz para ajustarla a la ventana
+const appEl = document.getElementById('app');
+function resizeGame(){
+  // restablecer dimensiones originales
+  appEl.style.transform = 'none';
+  appEl.style.position = 'static';
+  appEl.style.margin = '0 auto';
+  appEl.style.left = '';
+  appEl.style.top = '';
+  const baseWidth = appEl.offsetWidth;
+  const baseHeight = appEl.offsetHeight;
+  const scale = Math.min(window.innerWidth / baseWidth, window.innerHeight / baseHeight);
+  if (scale < 1){
+    appEl.style.transform = `scale(${scale})`;
+    appEl.style.transformOrigin = 'top left';
+    appEl.style.position = 'absolute';
+    appEl.style.left = `${(window.innerWidth - baseWidth * scale) / 2}px`;
+    appEl.style.top = `${(window.innerHeight - baseHeight * scale) / 2}px`;
+    appEl.style.margin = '0';
+  }
+}
+window.addEventListener('resize', resizeGame);
+resizeGame();
+
 canvas.focus();
 
 // Iniciar

--- a/tetris/js/renderer.js
+++ b/tetris/js/renderer.js
@@ -118,18 +118,18 @@ export class Renderer {
   drawRect(x, y, size, kind, flash=false){
     const ctx = this.ctx;
     const c = getCss(colorVar[kind] || '--panel');
+    ctx.save();
     // base
     ctx.fillStyle = c;
     ctx.fillRect(x, y, size, size);
     // borde sutil
-    ctx.strokeStyle = 'rgba(255,255,255,0.08)';
-    if (flash) ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+    ctx.strokeStyle = flash ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.08)';
     ctx.strokeRect(x+0.5, y+0.5, size-1, size-1);
     // highlight leve
     ctx.globalAlpha = flash ? 0.5 : 0.12;
     ctx.fillStyle = '#fff';
     ctx.fillRect(x+2, y+2, size-4, Math.max(2, size*0.18));
-    ctx.globalAlpha = 1;
+    ctx.restore();
   }
 
   // Mini canvases (hold y next)


### PR DESCRIPTION
## Summary
- Scale down game layout only when necessary to better fill the browser window
- Fix ghost piece rendering so landing preview is drawn with consistent transparency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68987b37b2c4832f98fbfcd84e1d0a0b