### PR TITLE
Scale Tetris interface and fix line clearing

### DIFF
--- a/tetris/css/styles.css
+++ b/tetris/css/styles.css
@@ -24,6 +24,7 @@ body{
   margin:0; background:var(--bg); color:var(--text);
   font:500 16px/1.4 system-ui,Segoe UI,Roboto,Arial,sans-serif;
   -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  overflow:hidden;
 }
 
 #app{

--- a/tetris/js/board.js
+++ b/tetris/js/board.js
@@ -66,12 +66,12 @@ export function fullRows(board) {
 // Compacta eliminando filas completas y añadiendo filas 0 arriba.
 // Devuelve número de líneas eliminadas.
 export function clearRows(board, rows) {
-  let count = 0;
-  for (const ry of rows) {
-    board.splice(ry - count, 1);
-    const newRow = new Array(COLS).fill(0);
-    board.unshift(newRow);
-    count++;
+  const ordered = [...rows].sort((a, b) => b - a);
+  for (const ry of ordered) {
+    board.splice(ry, 1);
   }
-  return count;
+  for (let i = 0; i < ordered.length; i++) {
+    board.unshift(new Array(COLS).fill(0));
+  }
+  return ordered.length;
 }

--- a/tetris/js/main.js
+++ b/tetris/js/main.js
@@ -142,6 +142,28 @@ setupTouch();
 // Focus inicial en el canvas para teclado
 canvas.addEventListener('pointerdown', ()=> canvas.focus(), {passive:true});
 canvas.tabIndex = 0;
+// Escalar la interfaz para ajustarla a la ventana
+const appEl = document.getElementById('app');
+function resizeGame(){
+  // restablecer dimensiones originales
+  appEl.style.transform = 'none';
+  appEl.style.position = 'static';
+  appEl.style.margin = '0 auto';
+  appEl.style.left = '';
+  appEl.style.top = '';
+  const baseWidth = appEl.offsetWidth;
+  const baseHeight = appEl.offsetHeight;
+  const scale = Math.min(window.innerWidth / baseWidth, window.innerHeight / baseHeight);
+  appEl.style.transform = `scale(${scale})`;
+  appEl.style.transformOrigin = 'top left';
+  appEl.style.position = 'absolute';
+  appEl.style.left = `${(window.innerWidth - baseWidth * scale) / 2}px`;
+  appEl.style.top = `${(window.innerHeight - baseHeight * scale) / 2}px`;
+  appEl.style.margin = '0';
+}
+window.addEventListener('resize', resizeGame);
+resizeGame();
+
 canvas.focus();
 
 // Iniciar

--- a/tetris/js/renderer.js
+++ b/tetris/js/renderer.js
@@ -118,18 +118,18 @@ export class Renderer {
   drawRect(x, y, size, kind, flash=false){
     const ctx = this.ctx;
     const c = getCss(colorVar[kind] || '--panel');
+    ctx.save();
     // base
     ctx.fillStyle = c;
     ctx.fillRect(x, y, size, size);
     // borde sutil
-    ctx.strokeStyle = 'rgba(255,255,255,0.08)';
-    if (flash) ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+    ctx.strokeStyle = flash ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.08)';
     ctx.strokeRect(x+0.5, y+0.5, size-1, size-1);
     // highlight leve
     ctx.globalAlpha = flash ? 0.5 : 0.12;
     ctx.fillStyle = '#fff';
     ctx.fillRect(x+2, y+2, size-4, Math.max(2, size*0.18));
-    ctx.globalAlpha = 1;
+    ctx.restore();
   }
 
   // Mini canvases (hold y next)


### PR DESCRIPTION
## Summary
- Scale and center Tetris layout based on window dimensions so the game enlarges or shrinks to fit the browser
- Fix ghost piece rendering so landing preview is drawn with consistent transparency
- Remove all simultaneous completed rows by deleting them bottom-up and injecting fresh empty rows at the top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68987b37b2c4832f98fbfcd84e1d0a0b