### PR TITLE
Fix shader compile error and improve input handling

### DIFF
--- a/planetary_webgpu_sim/src/initWebGPU.ts
+++ b/planetary_webgpu_sim/src/initWebGPU.ts
@@ -2,7 +2,10 @@ export async function initWebGPU(canvas: HTMLCanvasElement) {
   if (!('gpu' in navigator)) {
     throw new Error('Tu navegador no soporta WebGPU. Usa Chrome/Edge/Firefox nightly con WebGPU habilitado.');
   }
-  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
+  // Avoid passing powerPreference on Windows where it's ignored and triggers a warning
+  const adapter = await navigator.gpu.requestAdapter(
+    navigator.userAgent.includes('Windows') ? {} : { powerPreference: 'high-performance' }
+  );
   if (!adapter) throw new Error('No se encontró adaptador WebGPU.');
   const device = await adapter.requestDevice();
   const context = canvas.getContext('webgpu') as GPUCanvasContext;

--- a/planetary_webgpu_sim/src/main.ts
+++ b/planetary_webgpu_sim/src/main.ts
@@ -84,8 +84,9 @@ async function resetSim() {
     renderer = new Renderer(device, format);
     camera.attach(canvas);
   }
-  sim = new Simulation(device);
-  await sim.init(posType, velMass, aux, p);
+  const newSim = new Simulation(device);
+  await newSim.init(posType, velMass, aux, p);
+  sim = newSim;
   await renderer.init(sim.posType, sim.aux, sim.velMass);
   onResize();
   lastTime = performance.now();

--- a/planetary_webgpu_sim/src/orbitcam.ts
+++ b/planetary_webgpu_sim/src/orbitcam.ts
@@ -19,7 +19,7 @@ export class OrbitCamera {
     });
     canvas.addEventListener('wheel', (e) => {
       this.distance *= Math.pow(1.1, e.deltaY * 0.01);
-    });
+    }, { passive: true });
   }
 
   viewProj(aspect: number): Float32Array {

--- a/planetary_webgpu_sim/src/render.wgsl
+++ b/planetary_webgpu_sim/src/render.wgsl
@@ -50,7 +50,6 @@ fn vs_main(@builtin(instance_index) inst: u32, @location(0) quadPos: vec2<f32>) 
 
 @fragment
 fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
-fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
 
   // Render a smooth circle sprite using quadPos in [-1,1]^2 generated in vertex buffer
   let r2 = dot(in.quadPos, in.quadPos);


### PR DESCRIPTION
## Summary
- fix fragment shader syntax causing WebGPU pipeline failure
- mark wheel event listener as passive for smoother scrolling
- avoid WebGPU adapter warning on Windows
- create new Simulation only after initialization completes to prevent GPUBuffer errors on reset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: sh: 1: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e9ce464832f92553355fe772421